### PR TITLE
Ensure we build packages using C++17

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,3 +18,7 @@ common --tool_java_runtime_version=17
 # for bazel@HEAD and rolling releases.
 # https://github.com/bazelbuild/bazel/pull/26119
 common --repositories_without_autoloads=bazel_features_version,bazel_features_glob
+
+# Newer versions of protobuf require downstream transitive projects to set C++ language version flags.
+common --cxxopt=-std=c++17
+common --host_cxxopt=-std=c++17


### PR DESCRIPTION
For compatibility with newer versions of protobuf. See https://github.com/bazelbuild/rules_android/issues/400#issuecomment-3168976214 for more details.